### PR TITLE
mark-devkit: Bump net-vpn/networkmanager-strongswan-1.6.0

### DIFF
--- a/net-vpn/networkmanager-strongswan/Manifest
+++ b/net-vpn/networkmanager-strongswan/Manifest
@@ -1,0 +1,1 @@
+DIST NetworkManager-strongswan-1.6.0.tar.bz2 302787 SHA512 ecfae6c100f9344d07a9d67f01894edbd509178698ad3bce6f8c1ccdd53e08baca4e95c10f7f72991b163042f9cc19d876bcf71ab8b2efb10a25c5e00fe03572

--- a/net-vpn/networkmanager-strongswan/networkmanager-strongswan-1.6.0.ebuild
+++ b/net-vpn/networkmanager-strongswan/networkmanager-strongswan-1.6.0.ebuild
@@ -1,0 +1,59 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit autotools
+
+MY_PN="NetworkManager"
+MY_P="${P/networkmanager/${MY_PN}}"
+
+DESCRIPTION="NetworkManager StrongSwan plugin"
+HOMEPAGE="https://www.strongswan.org/"
+SRC_URI="https://download.strongswan.org/${MY_PN}/${MY_P}.tar.bz2"
+S="${WORKDIR}/${MY_P}"
+
+LICENSE="GPL-2+"
+SLOT="0"
+KEYWORDS="*"
+IUSE="gtk4"
+
+RDEPEND="
+	app-crypt/libsecret
+	>=net-libs/libnma-1.1.0
+	net-misc/networkmanager
+	>=net-vpn/strongswan-5.8.3[networkmanager]
+	!gtk4? ( x11-libs/gtk+:3 )
+	gtk4? (
+		net-libs/libnma
+		gui-libs/gtk:4
+	)
+"
+
+DEPEND="${RDEPEND}"
+
+BDEPEND="
+	dev-util/intltool
+	virtual/pkgconfig
+"
+
+src_prepare() {
+	default
+
+	eautoreconf
+}
+
+src_configure() {
+	local myeconfargs=(
+		# Don't enable all warnings, as some are treated as errors and the compilation will fail
+		--disable-more-warnings
+		--disable-static
+	)
+
+	econf "${myeconfargs[@]}"
+}
+
+src_install() {
+	default
+
+	find "${D}" -name '*.la' -delete || die
+}


### PR DESCRIPTION
Automatic bump of package net-vpn/networkmanager-strongswan-1.6.0 for branch mark-unstable by mark-bot