### PR TITLE
mark-devkit: Bump virtual/mailx-1

### DIFF
--- a/virtual/mailx/mailx-1.ebuild
+++ b/virtual/mailx/mailx-1.ebuild
@@ -1,0 +1,13 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=5
+
+DESCRIPTION="Virtual for mail implementations"
+SLOT="0"
+KEYWORDS="*"
+
+RDEPEND="|| (	net-mail/mailutils
+				mail-client/mailx
+				mail-client/nail
+				mail-client/s-nail
+				sys-freebsd/freebsd-ubin )"


### PR DESCRIPTION
Automatic bump of package virtual/mailx-1 for branch mark-unstable by mark-bot