### PR TITLE
mark-devkit: Bump net-analyzer/tcpflow-1.5.2-r1

### DIFF
--- a/net-analyzer/tcpflow/tcpflow-1.5.2-r1.ebuild
+++ b/net-analyzer/tcpflow/tcpflow-1.5.2-r1.ebuild
@@ -21,6 +21,7 @@ IUSE="cairo test"
 
 RDEPEND="
 	dev-db/sqlite
+	dev-lang/python:2.7=
 	dev-libs/boost:=
 	dev-libs/openssl:=
 	net-libs/http-parser:=


### PR DESCRIPTION
Automatic bump of package net-analyzer/tcpflow-1.5.2-r1 for branch mark-xl by mark-bot