### PR TITLE
mark-devkit: Bump net-libs/libvncserver-0.9.15-r1

### DIFF
--- a/net-libs/libvncserver/libvncserver-0.9.15-r1.ebuild
+++ b/net-libs/libvncserver/libvncserver-0.9.15-r1.ebuild
@@ -51,7 +51,6 @@ post_src_unpack() {
 
 src_configure() {
 	local mycmakeargs=(
-		-DWITH_EXAMPLES=OFF
 		-DWITH_FFMPEG=OFF
 		-DWITH_GTK=OFF
 		-DWITH_SDL=OFF


### PR DESCRIPTION
Automatic bump of package net-libs/libvncserver-0.9.15-r1 for branch mark-iii by mark-bot