### PR TITLE
mark-devkit: Bump net-dns/bind-tools-9.21.7-r1

### DIFF
--- a/net-dns/bind-tools/bind-tools-9.21.7-r1.ebuild
+++ b/net-dns/bind-tools/bind-tools-9.21.7-r1.ebuild
@@ -31,6 +31,7 @@ DEPEND="${COMMON_DEPEND}"
 RDEPEND="${COMMON_DEPEND}
 	!<=net-dns/bind-9.18.1-r2
 "
+S="${WORKDIR}/bind-9.21.7"
 
 # sphinx required for man-page and html creation
 BDEPEND="


### PR DESCRIPTION
Automatic bump of package net-dns/bind-tools-9.21.7-r1 for branch mark-unstable by mark-bot