### PR TITLE
mark-devkit: Bump net-vpn/networkmanager-vpnc-1.2.6-r1

### DIFF
--- a/net-vpn/networkmanager-vpnc/networkmanager-vpnc-1.2.6-r1.ebuild
+++ b/net-vpn/networkmanager-vpnc/networkmanager-vpnc-1.2.6-r1.ebuild
@@ -44,7 +44,6 @@ src_configure() {
 	gnome2_src_configure \
 		--disable-more-warnings \
 		--disable-static \
-		--with-dist-version=MacaroniOS \
-		$(use_with gtk gnome) \
-		--without-libnm-glib
+		--with-dist-version=Gentoo \
+		$(use_with gtk gnome)
 }


### PR DESCRIPTION
Automatic bump of package net-vpn/networkmanager-vpnc-1.2.6-r1 for branch mark-unstable by mark-bot