### PR TITLE
mark-devkit: Bump mail-client/alpine-2.26-r1

### DIFF
--- a/mail-client/alpine/alpine-2.26-r1.ebuild
+++ b/mail-client/alpine/alpine-2.26-r1.ebuild
@@ -13,9 +13,11 @@ KEYWORDS="*"
 IUSE="ipv6 kerberos ldap passfile nls smime ssl"
 RDEPEND="app-misc/mime-types
 	sys-libs/ncurses
+	virtual/libcrypt
 	kerberos? ( app-crypt/mit-krb5 )
 	ldap? ( net-nds/openldap )
 	ssl? ( dev-libs/openssl )
+	
 "
 DEPEND="${RDEPEND}
 "


### PR DESCRIPTION
Automatic bump of package mail-client/alpine-2.26-r1 for branch mark-xl by mark-bot