### PR TITLE
mark-devkit: Bump net-vpn/networkmanager-fortisslvpn-1.2.8-r1

### DIFF
--- a/net-vpn/networkmanager-fortisslvpn/networkmanager-fortisslvpn-1.2.8-r1.ebuild
+++ b/net-vpn/networkmanager-fortisslvpn/networkmanager-fortisslvpn-1.2.8-r1.ebuild
@@ -37,7 +37,8 @@ DEPEND="${RDEPEND}
 src_configure() {
 	gnome2_src_configure \
 		--disable-static \
-		--with-dist-version=Gentoo \
+		--with-dist-version=MacaroniOS \
 		--localstatedir=/var \
-		$(use_with gtk gnome)
+		$(use_with gtk gnome) \
+		--without-libnm-glib
 }


### PR DESCRIPTION
Automatic bump of package net-vpn/networkmanager-fortisslvpn-1.2.8-r1 for branch mark-iii by mark-bot