### PR TITLE
mark-devkit: [mark-unstable] Bump net-dns/bind-tools-9.21.14

### DIFF
--- a/net-dns/bind-tools/bind-tools-9.21.14.ebuild
+++ b/net-dns/bind-tools/bind-tools-9.21.14.ebuild
@@ -1,0 +1,65 @@
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit meson flag-o-matic toolchain-funcs
+
+DESCRIPTION="bind tools: dig, nslookup, host, nsupdate, dnssec-keygen"
+HOMEPAGE="https://www.isc.org/software/bind"
+SRC_URI="https://downloads.isc.org/isc/bind9/9.21.14/bind-9.21.14.tar.xz -> bind-9.21.14.tar.xz"
+
+LICENSE="Apache-2.0 BSD BSD-2 GPL-2 HPND ISC MPL-2.0"
+SLOT="0"
+KEYWORDS="*"
+IUSE="caps gssapi idn ipv6 libedit readline xml"
+# no PKCS11 currently as it requires OpenSSL to be patched, also see bug 409687
+
+COMMON_DEPEND="
+	dev-libs/libuv:=
+	dev-libs/openssl
+	dev-libs/userspace-rcu
+	sys-libs/libcap
+	xml? ( dev-libs/libxml2 )
+	idn? ( net-dns/libidn2:= )
+	gssapi? ( virtual/krb5 )
+	libedit? ( dev-libs/libedit )
+	!libedit? (
+		readline? ( sys-libs/readline:= )
+	)
+"
+DEPEND="${COMMON_DEPEND}"
+RDEPEND="${COMMON_DEPEND}
+	!<=net-dns/bind-9.18.1-r2
+"
+S="${WORKDIR}/bind-9.21.14"
+
+# sphinx required for man-page and html creation
+BDEPEND="
+	virtual/pkgconfig
+"
+
+src_configure() {
+	local emesonargs=(
+		--sysconfdir=/etc/bind
+		--localstatedir=/var
+		-Ddoc=disabled
+		-Dzlib=disabled
+		-Dstats-json=disabled
+		-Dstats-xml=disabled
+		-Dlmdb=disabled
+		$(meson_feature caps cap)
+		$(meson_feature gssapi)
+		$(meson_feature idn)
+	)
+	meson_src_configure
+}
+
+src_install() {
+	meson_src_install
+
+	rm -r "${D}"/usr/bin/{arpaname,named*,nsec3hash} || die
+	rm -r "${D}"/usr/sbin || die
+	rm "${D}"/usr/share/doc/${P}/{NEWS,ChangeLog} || die
+}
+
+# vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package net-dns/bind-tools-9.21.14 for branch mark-unstable by mark-bot