### PR TITLE
mark-devkit: [mark-xl] Bump net-dns/bind-tools-9.21.15-r1

### DIFF
--- a/net-dns/bind-tools/bind-tools-9.21.15-r1.ebuild
+++ b/net-dns/bind-tools/bind-tools-9.21.15-r1.ebuild
@@ -11,7 +11,7 @@ SRC_URI="https://downloads.isc.org/isc/bind9/9.21.15/bind-9.21.15.tar.xz -> bind
 LICENSE="Apache-2.0 BSD BSD-2 GPL-2 HPND ISC MPL-2.0"
 SLOT="0"
 KEYWORDS="*"
-IUSE="gssapi idn ipv6 libedit readline xml"
+IUSE="caps gssapi idn ipv6 libedit readline xml"
 # no PKCS11 currently as it requires OpenSSL to be patched, also see bug 409687
 
 COMMON_DEPEND="
@@ -47,6 +47,7 @@ src_configure() {
 		-Dstats-json=disabled
 		-Dstats-xml=disabled
 		-Dlmdb=disabled
+		$(meson_feature caps cap)
 		$(meson_feature gssapi)
 		$(meson_feature idn)
 	)


### PR DESCRIPTION
Automatic bump of package net-dns/bind-tools-9.21.15-r1 for branch mark-xl by mark-bot