### PR TITLE
mark-devkit: [mark-iii] Bump net-misc/spice-gtk-0.42-r1

### DIFF
--- a/net-misc/spice-gtk/spice-gtk-0.42-r1.ebuild
+++ b/net-misc/spice-gtk/spice-gtk-0.42-r1.ebuild
@@ -61,7 +61,6 @@ DEPEND="${RDEPEND}
 "
 BDEPEND="
 	dev-perl/Text-CSV
-	dev-util/glib-utils
 	sys-devel/gettext
 	virtual/pkgconfig
 	$(python_gen_any_dep '


### PR DESCRIPTION
Automatic bump of package net-misc/spice-gtk-0.42-r1 for branch mark-iii by mark-bot