### PR TITLE
mark-devkit: [mark-xl] Bump net-misc/networkmanager-1.52.0-r1

### DIFF
--- a/net-misc/networkmanager/networkmanager-1.52.0-r1.ebuild
+++ b/net-misc/networkmanager/networkmanager-1.52.0-r1.ebuild
@@ -89,7 +89,6 @@ DEPEND="${COMMON_DEPEND}
 "
 BDEPEND="
 	dev-util/gdbus-codegen
-	dev-util/glib-utils
 	gtk-doc? (
 		dev-util/gtk-doc
 		app-text/docbook-xml-dtd:4.1.2


### PR DESCRIPTION
Automatic bump of package net-misc/networkmanager-1.52.0-r1 for branch mark-xl by mark-bot