### PR TITLE
mark-devkit: [mark-31] Bump net-dns/avahi-0.8-r1

### DIFF
--- a/net-dns/avahi/avahi-0.8-r1.ebuild
+++ b/net-dns/avahi/avahi-0.8-r1.ebuild
@@ -55,7 +55,6 @@ RDEPEND="
 "
 
 BDEPEND="
-	dev-util/glib-utils
 	doc? ( app-doc/doxygen )
 	app-doc/xmltoman
 	sys-devel/gettext


### PR DESCRIPTION
Automatic bump of package net-dns/avahi-0.8-r1 for branch mark-31 by mark-bot