### PR TITLE
mark-devkit: [mark-31] Bump net-libs/libmbim-1.32.0-r1

### DIFF
--- a/net-libs/libmbim/libmbim-1.32.0-r1.ebuild
+++ b/net-libs/libmbim/libmbim-1.32.0-r1.ebuild
@@ -17,6 +17,5 @@ RDEPEND=">=dev-libs/glib-2.56:2
 DEPEND="${RDEPEND}"
 BDEPEND="
 	app-shells/bash-completion
-	dev-util/glib-utils
 	virtual/pkgconfig
 "


### PR DESCRIPTION
Automatic bump of package net-libs/libmbim-1.32.0-r1 for branch mark-31 by mark-bot