### PR TITLE
mark-devkit: [mark-31] Bump net-libs/libsignon-glib-2.1-r1

### DIFF
--- a/net-libs/libsignon-glib/libsignon-glib-2.1-r1.ebuild
+++ b/net-libs/libsignon-glib/libsignon-glib-2.1-r1.ebuild
@@ -28,7 +28,6 @@ RDEPEND="
 DEPEND="${RDEPEND}"
 BDEPEND="
 	dev-util/gdbus-codegen
-	dev-util/glib-utils
 	doc? ( dev-util/gtk-doc )
 	test? ( dev-libs/check )
 "


### PR DESCRIPTION
Automatic bump of package net-libs/libsignon-glib-2.1-r1 for branch mark-31 by mark-bot