### PR TITLE
mark-devkit: [mark-31] Bump net-libs/libdmapsharing-2.9.39-r1

### DIFF
--- a/net-libs/libdmapsharing/libdmapsharing-2.9.39-r1.ebuild
+++ b/net-libs/libdmapsharing/libdmapsharing-2.9.39-r1.ebuild
@@ -26,7 +26,6 @@ RDEPEND="
 	introspection? ( >=dev-libs/gobject-introspection-1.30:= )
 "
 DEPEND="${RDEPEND}
-	dev-util/glib-utils
 	dev-util/gtk-doc-am
 	virtual/pkgconfig
 	test? ( >=dev-libs/check-0.9.4 )


### PR DESCRIPTION
Automatic bump of package net-libs/libdmapsharing-2.9.39-r1 for branch mark-31 by mark-bot