### PR TITLE
mark-devkit: [mark-31] Bump net-misc/modemmanager-1.24.0-r1

### DIFF
--- a/net-misc/modemmanager/modemmanager-1.24.0-r1.ebuild
+++ b/net-misc/modemmanager/modemmanager-1.24.0-r1.ebuild
@@ -33,7 +33,6 @@ DEPEND="
 RDEPEND="${DEPEND}"
 BDEPEND="
 	dev-util/gdbus-codegen
-	dev-util/glib-utils
 	>=dev-util/gtk-doc-am-1
 	>=sys-devel/gettext-0.19.8
 	virtual/pkgconfig


### PR DESCRIPTION
Automatic bump of package net-misc/modemmanager-1.24.0-r1 for branch mark-31 by mark-bot