### PR TITLE
mark-devkit: [mark-xl] Bump net-libs/libnetfilter_log-1.0.2-r1

### DIFF
--- a/net-libs/libnetfilter_log/libnetfilter_log-1.0.2-r1.ebuild
+++ b/net-libs/libnetfilter_log/libnetfilter_log-1.0.2-r1.ebuild
@@ -18,7 +18,7 @@ RDEPEND=">=net-libs/libnfnetlink-1.0.0
 	>=net-libs/libmnl-1.0.3"
 DEPEND="${RDEPEND}"
 BDEPEND="virtual/pkgconfig
-	doc? ( app-text/doxygen )"
+	doc? ( app-doc/doxygen )"
 
 CONFIG_CHECK="~NETFILTER_NETLINK_LOG"
 


### PR DESCRIPTION
Automatic bump of package net-libs/libnetfilter_log-1.0.2-r1 for branch mark-xl by mark-bot