### PR TITLE
Update bind-tools-9.21.21.ebuild

### DIFF
--- a/net-dns/bind-tools/bind-tools-9.21.21.ebuild
+++ b/net-dns/bind-tools/bind-tools-9.21.21.ebuild
@@ -17,6 +17,7 @@ IUSE="gssapi idn ipv6 libedit readline xml"
 COMMON_DEPEND="
 	dev-libs/libuv:=
 	dev-libs/openssl
+	dev-db/lmdb
 	dev-libs/userspace-rcu
 	sys-libs/libcap
 	xml? ( dev-libs/libxml2 )


### PR DESCRIPTION
bind-tools requires the dev-db/lmdb ebuild to compile.