### PR TITLE
mark-devkit: [mark-iii] Bump net-dns/bind-tools-9.21.21-r1

### DIFF
--- a/net-dns/bind-tools/bind-tools-9.21.21-r1.ebuild
+++ b/net-dns/bind-tools/bind-tools-9.21.21-r1.ebuild
@@ -19,6 +19,7 @@ COMMON_DEPEND="
 	dev-libs/openssl
 	dev-libs/userspace-rcu
 	sys-libs/libcap
+	dev-db/lmdb
 	xml? ( dev-libs/libxml2 )
 	idn? ( net-dns/libidn2:= )
 	gssapi? ( virtual/krb5 )
@@ -46,7 +47,6 @@ src_configure() {
 		-Dzlib=disabled
 		-Dstats-json=disabled
 		-Dstats-xml=disabled
-		-Dlmdb=disabled
 		$(meson_feature gssapi)
 		$(meson_feature idn)
 	)
@@ -58,7 +58,6 @@ src_install() {
 
 	rm -r "${D}"/usr/bin/{arpaname,named*,nsec3hash} || die
 	rm -r "${D}"/usr/sbin || die
-	rm "${D}"/usr/share/doc/${P}/{NEWS,ChangeLog} || die
 }
 
 # vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package net-dns/bind-tools-9.21.21-r1 for branch mark-iii by mark-bot