### PR TITLE
mark-devkit: [mark-xl] Bump net-misc/freerdp-3.25.0-r1

### DIFF
--- a/net-misc/freerdp/freerdp-3.25.0-r1.ebuild
+++ b/net-misc/freerdp/freerdp-3.25.0-r1.ebuild
@@ -57,6 +57,7 @@ RDEPEND="dev-libs/openssl:0=
 	sdl? (
 	  media-libs/libsdl2
 	  media-libs/sdl2-ttf
+	  media-libs/sdl3-ttf
 	)
 	server? (
 	  X? (


### PR DESCRIPTION
Automatic bump of package net-misc/freerdp-3.25.0-r1 for branch mark-xl by mark-bot